### PR TITLE
Upgrade JSCover and JSCover maven plugin

### DIFF
--- a/bookmarks.html
+++ b/bookmarks.html
@@ -6,8 +6,7 @@
 
 <h1>General</h1>
 <a href="http://github.com/tntim96/JSCover-samples/" target="_blank">JSCover Samples Project On GitHub</a><br/>
-<a href="https://drone.io/" target="_blank">Drone.io Continuous Integration</a><br/>
-<a href="https://drone.io/github.com/tntim96/JSCover-samples/files/target/site/surefire-report.html" target="_blank">Drone.io CI Surefire Report</a><br/>
+<a href="https://travis-ci.org/tntim96/JSCover-samples" target="_blank">Travis-CI Continuous Integration</a><br/>
 
 <h1>Test Reports</h1>
 <a href="target/site/surefire-report.html" target="_blank">Unit Tests</a><br/>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <selenium.version>3.141.59</selenium.version>
-        <jscovermp.version>2.0.6-SNAPSHOT</jscovermp.version>
+        <jscovermp.version>2.0.6</jscovermp.version>
     </properties>
 
     <prerequisites>
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.github.tntim96</groupId>
             <artifactId>JSCover</artifactId>
-            <version>2.0.7-SNAPSHOT</version>
+            <version>2.0.7</version>
         </dependency>
         <dependency>
             <groupId>com.github.tntim96</groupId>


### PR DESCRIPTION
Upgrade JSCover 2.0.7-SNAPSHOT to 2.0.7, JSCover maven plugin 2.0.6-SNAPSHOT to 2.0.6